### PR TITLE
feat(order): MatchedNameExtractOrder 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,32 @@ errorData.element?.focus();
 
 When you pass the `FieldErrorDataOrder` array as a parameter to the extract method, it finds the most appropriate error data from `FieldErrors`. The `FieldErrorDataOrder` is applied in order, and in the example above, it extracts the error data from the `FieldError` that has a message and appears first in DOM order.
 
-- `MessageExistExtractOrder({ trim: boolean })`: `FieldError` that contain a message are prioritized. When comparing `undefined` and an empty string, the empty string takes precedence. The `trim` option determines whether to trim the message of a `FieldError` before comparison.
-- `DomPlaceExtractOrder()`: `FieldError` that appear earlier in the DOM are given higher priority. `FieldError` without an assigned ref have the lowest priority.
+#### MessageExistExtractOrder
+
+```
+MessageExistExtractOrder({ trim: boolean })
+```
+
+`FieldError` that contain a message are prioritized. When comparing `undefined` and an empty string, the empty string takes precedence. The `trim` option determines whether to trim the message of a `FieldError` before comparison.
+
+#### DomPlaceExtractOrder
+
+```
+DomPlaceExtractOrder()
+```
+
+`FieldError` that appear earlier in the DOM are given higher priority. `FieldError` without an assigned ref have the lowest priority.
+
+#### MatchedNameExtractOrder
+
+```
+MatchedNameExtractOrder<
+  TFieldValues extends FieldValues,
+  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>(nameList: Array<TFieldName>, { exact: boolean })
+```
+
+Priority is determined by matching the name of the field where the error occurred. The order of the `nameList` array defines the priority. If the `exact` option is enabled, the field name must match exactly to be considered for priority.
 
 ## Custom Extract Order
 

--- a/src/__tests__/fieldErrorExtractor.zod.test.tsx
+++ b/src/__tests__/fieldErrorExtractor.zod.test.tsx
@@ -54,7 +54,7 @@ describe('Does the FieldErrorExtractor extract data well for various field types
         }}
         onSubmitInvalid={(fieldErrors) => {
           const extractor = new FieldErrorExtractor(fieldErrors);
-          invlaidSubmitResultTestFn(extractor.extract().message);
+          invlaidSubmitResultTestFn(extractor.extract()?.message);
         }}
       >
         <TestFields />
@@ -125,7 +125,7 @@ describe('Does the FieldErrorExtractor extract data well for various field types
         }}
         onSubmitInvalid={(fieldErrors) => {
           const extractor = new FieldErrorExtractor(fieldErrors);
-          invlaidSubmitResultTestFn(extractor.extract().message);
+          invlaidSubmitResultTestFn(extractor.extract()?.message);
         }}
       >
         <TestFields />
@@ -188,7 +188,7 @@ describe('Does the FieldErrorExtractor extract data well for various field types
         }}
         onSubmitInvalid={(fieldErrors) => {
           const extractor = new FieldErrorExtractor(fieldErrors);
-          invlaidSubmitResultTestFn(extractor.extract().message);
+          invlaidSubmitResultTestFn(extractor.extract()?.message);
         }}
       >
         <TestFields />

--- a/src/extractOrders.ts
+++ b/src/extractOrders.ts
@@ -1,3 +1,5 @@
+import type { FieldPath, FieldValues } from 'react-hook-form';
+
 import type { FieldErrorData, FieldErrorDataOrder } from './logics/fieldErrorData';
 import { CompareFieldErrorDataResult } from './logics/fieldErrorData';
 
@@ -59,5 +61,38 @@ export class DomPlaceExtractOrder implements FieldErrorDataOrder {
     }
 
     return CompareFieldErrorDataResult.Equal;
+  }
+}
+
+export class MatchedNameExtractOrder<
+  TFieldValues extends FieldValues,
+  TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> implements FieldErrorDataOrder
+{
+  private readonly nameList: Array<TFieldName>;
+  private readonly exactOption: boolean;
+
+  constructor(nameList: Array<TFieldName>, options?: { exact?: boolean }) {
+    this.nameList = Array.from(new Set(nameList));
+    this.exactOption = options?.exact ?? false;
+  }
+
+  public compare(data1: FieldErrorData, data2: FieldErrorData): CompareFieldErrorDataResult {
+    const index1 = this.nameList.findIndex((name) => this.matchName(name, data1));
+    const index2 = this.nameList.findIndex((name) => this.matchName(name, data2));
+
+    if (index1 === index2) {
+      return CompareFieldErrorDataResult.Equal;
+    }
+
+    if (index1 >= 0 && index2 >= 0) {
+      return index1 < index2 ? CompareFieldErrorDataResult.First : CompareFieldErrorDataResult.Second;
+    }
+
+    return index1 < 0 ? CompareFieldErrorDataResult.Second : CompareFieldErrorDataResult.First;
+  }
+
+  private matchName(name: TFieldName, data: FieldErrorData) {
+    return this.exactOption ? data.name === name : data.name.startsWith(name);
   }
 }

--- a/src/fieldErrorExtractor.ts
+++ b/src/fieldErrorExtractor.ts
@@ -6,22 +6,35 @@ import { FieldErrorData } from './logics/fieldErrorData';
 export class FieldErrorExtractor<TFieldValues extends FieldValues> {
   constructor(private readonly fieldErrors: FieldErrors<TFieldValues>) {}
 
-  public extract(orders: Array<FieldErrorDataOrder> = []): FieldErrorData {
-    return this.extractRecursively(this.fieldErrors, orders);
+  public extract(orders: Array<FieldErrorDataOrder> = []): FieldErrorData | undefined {
+    return this.extractRecursively('', this.fieldErrors, orders);
   }
 
-  private extractRecursively(error: unknown, orders: Array<FieldErrorDataOrder> = []): FieldErrorData {
+  private extractRecursively(
+    name: string,
+    error: unknown,
+    orders: Array<FieldErrorDataOrder> = [],
+  ): FieldErrorData | undefined {
     if (typeof error !== 'object' || error === null || error instanceof HTMLElement) {
-      return new FieldErrorData(undefined, undefined);
+      return undefined;
     }
 
     // - The properties of FieldErrorsImpl merged with FieldError are difficult to type explicitly.
     // - A property could belong to FieldError, or it could be a FieldError of a sub FieldValue, or a merged type of both.
     // - Therefore, in extractFromError, the error parameter is typed as unknown.
     // - If the parameter is neither a GlobalError nor a FieldError, the function iterates through all properties to extract messages.
-    return Object.values(error).reduce<FieldErrorData>((acc, cur) => {
-      const extractedFieldError = this.extractRecursively(cur, orders);
-      return acc.compare(extractedFieldError, orders);
-    }, FieldErrorData.fromError(error));
+    return Object.entries(error).reduce<FieldErrorData | undefined>(
+      (fieldErrorData, [key, childError]) => {
+        const childName = name === '' ? key : `${name}.${key}`;
+        const childFieldErrorData = this.extractRecursively(childName, childError, orders);
+
+        if (fieldErrorData && childFieldErrorData) {
+          return fieldErrorData.compare(childFieldErrorData, orders);
+        }
+
+        return fieldErrorData ?? childFieldErrorData;
+      },
+      FieldErrorData.fromError(name, error),
+    );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { DomPlaceExtractOrder, MessageExistExtractOrder } from './extractOrders';
+export { DomPlaceExtractOrder, MatchedNameExtractOrder, MessageExistExtractOrder } from './extractOrders';
 export { FieldErrorExtractor } from './fieldErrorExtractor';
 export { CompareFieldErrorDataResult, FieldErrorData, FieldErrorDataOrder } from './logics/fieldErrorData';

--- a/src/logics/fieldErrorData.ts
+++ b/src/logics/fieldErrorData.ts
@@ -9,21 +9,22 @@ export interface FieldErrorDataOrder {
 }
 
 export class FieldErrorData {
-  public static fromError(error: object): FieldErrorData {
+  public static fromError(name: string, error: object): FieldErrorData | undefined {
     const message = 'message' in error && typeof error.message === 'string' ? error.message : undefined;
     const element = 'ref' in error && error.ref instanceof HTMLElement ? error.ref : undefined;
 
-    return new FieldErrorData(message, element);
+    if (message === undefined && element === undefined) {
+      return undefined;
+    }
+
+    return new FieldErrorData(name, message, element);
   }
 
-  constructor(
+  private constructor(
+    public readonly name: string,
     public readonly message: string | undefined,
     public readonly element: HTMLElement | undefined,
   ) {}
-
-  public isEmpty() {
-    return this.message === undefined && this.element === undefined;
-  }
 
   public compare(data: FieldErrorData, orders: Array<FieldErrorDataOrder> = []): FieldErrorData {
     for (const order of orders) {
@@ -35,13 +36,6 @@ export class FieldErrorData {
       if (result === CompareFieldErrorDataResult.Second) {
         return data;
       }
-    }
-
-    if (this.isEmpty() && data.isEmpty()) {
-      return this;
-    }
-    if (this.isEmpty()) {
-      return data;
     }
 
     return this;


### PR DESCRIPTION
- extract의 return type을 optional로 변경
- `FieldErrorData`에 `name` 포로퍼티 추가
- MatchedNameExtractOrder 구현 후 test code 작성